### PR TITLE
Resultschanges

### DIFF
--- a/assets/javaScript/javaScript.js
+++ b/assets/javaScript/javaScript.js
@@ -59,7 +59,6 @@ function tokenHandler(authCode) {
 // *Updated - now detects missing login, forces refresh after getting TOKEN. ----Retrieves and sets the oAuthToken when function is triggered. 
 
 function getToken() {
-
   fetch("https://accounts.spotify.com/api/token", {
     body: "grant_type=authorization_code&code=" + authCode + "&redirect_uri=https%3A%2F%2Fchrisonions.github.io%2Fwebdevawesometeam%2F",
     headers: {
@@ -86,6 +85,7 @@ function getToken() {
       console.log(error);
     })
 }
+
 getToken()
 
 
@@ -133,7 +133,6 @@ function searchHandler() {
     }
     else {
       console.log('listener active')
-      getToken();
       console.log('token got');
       getSeeds();
     }

--- a/assets/javaScript/javaScript.js
+++ b/assets/javaScript/javaScript.js
@@ -119,6 +119,7 @@ closeModle.onclick = function () {
   modal.style.display = "none";
 }
 
+// updated to remove 'getToken' call
 function searchHandler() {
   if (inputs.value == '') {
     modal.style.display = "block";

--- a/assets/javaScript/javaScript.js
+++ b/assets/javaScript/javaScript.js
@@ -20,7 +20,7 @@ var track = document.querySelector("#track");
 var artist = document.querySelector("#artist");
 var plLength = Number(document.querySelector('#playlistLengthNumber').value);
 var recommendations = '';
-var randomGenre = ["POP", "HIPHOP","HIP HOP","HIP-HOP","ROCK","INDIE","DANCE","ELECTRONIC","MOOD","ALTERNATIVE","COUNTRY","JAZZ","BLUES","CHILL","WORKOUT","RNB","R&B"]
+var randomGenre = ["POP", "HIPHOP", "HIP HOP", "HIP-HOP", "ROCK", "INDIE", "DANCE", "ELECTRONIC", "MOOD", "ALTERNATIVE", "COUNTRY", "JAZZ", "BLUES", "CHILL", "WORKOUT", "RNB", "R&B"]
 
 
 function requestAccessToUserData() {
@@ -66,7 +66,7 @@ function getToken() {
       "Content-Type": "application/x-www-form-urlencoded"
     },
     method: "POST"
-    })
+  })
     .then(function (response) {
       if (response.status >= 200 && response.status < 300) {
         return response.json();
@@ -99,9 +99,9 @@ searchButton.addEventListener('click', function (e) {
   e.preventDefault();
   searchHandler();
 })
-randomButton.addEventListener("click",function(r){
+randomButton.addEventListener("click", function (r) {
   r.preventDefault;
-  inputs.value = randomGenre[Math.floor(Math.random()*randomGenre.length)];
+  inputs.value = randomGenre[Math.floor(Math.random() * randomGenre.length)];
   searchHandler();
 })
 

--- a/assets/javaScript/results.js
+++ b/assets/javaScript/results.js
@@ -223,7 +223,7 @@ searchButton.addEventListener('click', function (e) {
 
 function searchHandler() {
     if (inputs.value == '') {
-        alert('enter a track name or artist name')
+        modal.style.display = "block";
     } else {
         entry = inputs.value;
         window.localStorage.setItem('searchCriteria', entry);
@@ -233,7 +233,6 @@ function searchHandler() {
         }
         else {
             console.log('listener active')
-            getToken();
             console.log('token got');
             getSeeds();
         }

--- a/assets/javaScript/results.js
+++ b/assets/javaScript/results.js
@@ -221,6 +221,7 @@ searchButton.addEventListener('click', function (e) {
     searchHandler();
 })
 
+// updated to remove 'getToken' call
 function searchHandler() {
     if (inputs.value == '') {
         modal.style.display = "block";

--- a/assets/javaScript/results.js
+++ b/assets/javaScript/results.js
@@ -77,8 +77,11 @@ function getUserPlaylists() {
     }).then(function (response) {
         return response.json()
     }).then(function (data) {
-        localStorage.setItem('myDetails', data);
-        var userID = data.id;
+        console.log(data);
+        localStorage.setItem('myDetails', JSON.stringify(data));
+    }).then(function () {
+        var userID = JSON.parse(localStorage.getItem('myDetails')).id;
+        console.log(userID);
         var url4 = "https://api.spotify.com/v1/users/" + userID + "/playlists";
         fetch(url4, {
             headers: {
@@ -86,18 +89,20 @@ function getUserPlaylists() {
                 "Content-Type": "application/json",
                 Authorization: "Bearer " + accessToken,
             }
+        }).then(function (response) {
+            console.log('passed');
+            return response.json()
+        }).then(function (data) {
+            localStorage.setItem('playlists', JSON.stringify(data))
+        }).then(function () {
+            console.log('arrived at next function call')
+        }).then(function () {
+            console.log('arrived at pl select function call')
+            createPLSelector();
         })
-    }).then(function (response) {
-        return response.json()
-    }).then(function (data) {
-        localStorage.setItem('playlists', JSON.stringify(data))
-    }).then(function () {
-        console.log('arrived at next function call')
-    }).then(function () {
-        createPLSelector();
     })
         .catch((error) => {
-            console.log(error)
+            console.log('fail' + error)
         })
 }
 getUserPlaylists()
@@ -137,6 +142,7 @@ function createPLSelector() {
 // ADD INDIVIDUAL TRACKS TO CHOSEN PL - TOKEN ISSUE - WORKS WITH DASHBOARD TOKEN BUT NOT OUR TOKEN??!!
 // Triggered by button click, see line 127 of 'createPLSelector'
 function add2ExistingPL() {
+    var accessToken = JSON.parse(localStorage.getItem('oAuthToken')).access_token;
     var m1 = inScopeTrackID.split(":");
     var m2 = m1[2];
     var finalTrackID = "spotify%3Atrack%3A" + m2;
@@ -145,7 +151,7 @@ function add2ExistingPL() {
     fetch(url5, {
         headers: {
             Accept: "application/json",
-            Authorization: "Bearer " + oAuthToken.access_token
+            Authorization: "Bearer " + accessToken
         },
         method: "POST"
     })


### PR DESCRIPTION
removed 'getToken' function call from the 'searchHandler' function - token will be retrieved on page load instead

We had an issue where subsequent searches after log in were calling GetToken using the shortlived authCode as input. This was causing an error message to be loaded into the oAuthToken stored variable, and causing all further api calls to fail. 

calling the getToken at page load resolves that issue. 

Note that a future commit will need a handler to deal with expired tokens (older than 60 mins).

fixed token issue when calling the playlist APIs and get user details api. We can now retrieve the user's user name and their existing playlists. 