### PR TITLE
Minorfix

### DIFF
--- a/assets/css/results.css
+++ b/assets/css/results.css
@@ -200,6 +200,12 @@ button:focus{
 .grid-item-playlist{
     align-self: center;
 }
+
+.album-cover{
+    width: 200px;
+    height: 200px;
+}
+
 #playlistTitle{
     grid-column: 1 / span 3;
     font-family: nimbus-sans-extended, sans-serif;

--- a/assets/javaScript/results.js
+++ b/assets/javaScript/results.js
@@ -127,7 +127,10 @@ function showResults() {
                 previewDiv.appendChild(audioEl);
                 playlistCard.appendChild(previewDiv);
             } else {
-                previewDiv.innerText += 'Preview unvailable';
+                let noPreview = document.createElement('div');
+                noPreview.setAttribute('class', 'noPreview');
+                noPreview.innerText = 'Preview unvailable';
+                playlistCard.appendChild(previewDiv);
             }
 
             // creating a div to hold playlist button and appending it to the playlist card

--- a/assets/javaScript/results.js
+++ b/assets/javaScript/results.js
@@ -142,7 +142,7 @@ function showResults() {
             resultsGrid.appendChild(playlistCard);
 
         }
-        // Calls function to add listeners over the added buttons
+        // Calls function to add listeners over the added buttons.
         addListeners()
     }
     // Catches the error if try was unsucessful

--- a/assets/javaScript/results.js
+++ b/assets/javaScript/results.js
@@ -101,6 +101,7 @@ function showResults() {
 
             let albumCov = document.createElement('img');
             albumCov.setAttribute('src', playL.tracks[i].album.images[1].url);
+            albumCov.setAttribute('class', 'album-cover');
             playlistCard.appendChild(albumCov);
 
             let trackN = document.createElement('h3')


### PR DESCRIPTION
'preview unavailable' wasnt displaying

in this change it is fixed. 

there is also a class added so we can modify the 'preview unavailable' section. 

if there is no preview then this code will run:

                let noPreview = document.createElement('div');
                noPreview.setAttribute('class', 'noPreview');
                noPreview.innerText = 'Preview unvailable';
                playlistCard.appendChild(previewDiv);